### PR TITLE
fix clone of daScript with --recurse-submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "quirrel"]
 	path = quirrel
-	url = git@github.com:GaijinEntertainment/quirrel.git
+	url = https://github.com/GaijinEntertainment/quirrel.git


### PR DESCRIPTION
change URL of "quirrel" module to https